### PR TITLE
Optimize lodash imports for tree shaking

### DIFF
--- a/src/artifacts.ts
+++ b/src/artifacts.ts
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import { uniqBy } from 'lodash';
 import { safeRequire } from './safe-require';
 import { state } from './state';
 
@@ -54,7 +54,7 @@ export const collectArtifacts = async () => {
     const grouped: Grouped = {};
     for (const [test, artifacts] of Object.entries(byTest)) {
       const group: Group = (grouped[test] = {});
-      const unique = _.uniqBy(artifacts, 'path');
+      const unique = uniqBy(artifacts, 'path');
       for (const artifact of unique) {
         if (!group[artifact.type]) group[artifact.type] = [];
         group[artifact.type]!.push(artifact.path);


### PR DESCRIPTION
This PR replaces the general lodash import (`import _ from 'lodash';`) with specific named imports for only the methods used.