### PR TITLE
Add cross-env to dev dependencies

### DIFF
--- a/examples/vite-vue-ts/package.json
+++ b/examples/vite-vue-ts/package.json
@@ -18,6 +18,7 @@
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^4.2.3",
+    "cross-env": "^7.0.3",
     "typescript": "^5.0.2",
     "vite": "^4.4.5",
     "vitest": "^0.34.3",


### PR DESCRIPTION
script `safetest` uses cross-env dependency and it is not listed in the project deps